### PR TITLE
Use local Mondale image

### DIFF
--- a/index.html
+++ b/index.html
@@ -360,7 +360,7 @@
                 <p>Led by experienced civic engagement professionals committed to community empowerment</p>
             </div>
             <div class="team-member">
-                <img src="https://via.placeholder.com/200x200/113d6a/ffce53?text=MR" alt="W. Mondale Robinson">
+                <img src="mondale.png" alt="W. Mondale Robinson">
                 <h3>W. Mondale Robinson</h3>
                 <p><strong>Executive Director</strong></p>
                 <p>W. Mondale Robinson currently serves as the youngest mayor of Enfield, North Carolina, his hometown city. He is the founder of the Black Male Voter Project, an initiative designed to increase the participation of Black men in electoral politics, and the former political director of Democracy for America, the progressive political action committee founded by former Democratic National Committee Chair Howard Dean.</p>


### PR DESCRIPTION
## Summary
- replace placeholder team image with mondale.png

## Testing
- `npm test` (fails: ENOENT package.json)
- `pytest` (no tests ran)


------
https://chatgpt.com/codex/tasks/task_e_689246b6afd8832ca63c8d511a3718c5